### PR TITLE
Prioritize TURN servers candidates in the order they are provided

### DIFF
--- a/candidate_relay.go
+++ b/candidate_relay.go
@@ -70,6 +70,22 @@ func NewCandidateRelay(config *CandidateRelayConfig) (*CandidateRelay, error) {
 	}, nil
 }
 
+func (c *CandidateRelay) LocalPreference() uint16 {
+	relayPreference := uint16(0)
+	switch c.relayProtocol {
+	case "tls":
+	case "dtls":
+		relayPreference = 2
+	case tcp:
+		relayPreference = 1
+	case udp:
+	default:
+		relayPreference = 0
+	}
+
+	return c.candidateBase.LocalPreference() + relayPreference
+}
+
 // RelayProtocol returns the protocol used between the endpoint and the relay server.
 func (c *CandidateRelay) RelayProtocol() string {
 	return c.relayProtocol


### PR DESCRIPTION
This attempts to reproduce libwebrtc's behavior, where the TURN servers candidates priority is based on the underlying relay protocol. UDP are preferred over TCP, which are preferred over the TLS options

We reuse the same factors as libwebrtc
https://github.com/mozilla/libwebrtc/blob/1389c76d9c79839a2ca069df1db48aa3f2e6a1ac/p2p/base/turn_port.cc#L61